### PR TITLE
Update JSONUtils.java

### DIFF
--- a/android-utils/src/main/java/github/nisrulz/androidutils/json/JSONUtils.java
+++ b/android-utils/src/main/java/github/nisrulz/androidutils/json/JSONUtils.java
@@ -64,7 +64,7 @@ public class JSONUtils {
      * @param filename the filename
      * @return the json object
      */
-    public JSONObject loadJSONFromAsset(Context context, String filename) {
+    public static JSONObject loadJSONFromAsset(Context context, String filename) {
         String json = null;
         JSONObject jsonObject = null;
         try {


### PR DESCRIPTION
loadJSONFromAsset is not accessible since you can not create an instance of JSONUtils

<!-- * Please fill out the blanks below describing your pull request * -->

**What does this implement/fix? Explain your changes**

Make a method accessible

**Does this close any currently open issues?**

no

**Any relevant logs, error output, bugreport etc?**
<!-- * If it’s long, please paste to https://ghostbin.com/ and insert the link here.) * -->

**Any other comments?**

+ **Where has this been tested?**

+ **Device Information:**

+ **Android Version:**

+ **Target Platform:**

+ **SDK Version:**

+ **Configuration Information:**

+ **Misc:** 

<!-- * More related information if you have can provide * -->